### PR TITLE
Scores command implemented. ( #44 )

### DIFF
--- a/Annie/Models/Anilist/MediaListCollection.cs
+++ b/Annie/Models/Anilist/MediaListCollection.cs
@@ -5,5 +5,6 @@ namespace AnnieMayDiscordBot.Models.Anilist
     public class MediaListCollection
     {
         public List<MediaListGroup> Lists { get; set; }
+        public User User { get; set; }
     }
 }

--- a/Annie/Models/UserScores.cs
+++ b/Annie/Models/UserScores.cs
@@ -1,0 +1,10 @@
+﻿namespace AnnieMayDiscordBot.Models
+{
+    public class UserScores
+    {
+        public int UpperBound { get; set; }
+        public int LowerBound { get; set; }
+        public float Count { get; set; }
+        public bool HasSAO { get; set; }
+    }
+}

--- a/Annie/Models/UserScores.cs
+++ b/Annie/Models/UserScores.cs
@@ -1,4 +1,7 @@
-﻿namespace AnnieMayDiscordBot.Models
+﻿using AnnieMayDiscordBot.Models.Anilist;
+using System.Collections.Generic;
+
+namespace AnnieMayDiscordBot.Models
 {
     public class UserScores
     {
@@ -6,5 +9,6 @@
         public int LowerBound { get; set; }
         public float Count { get; set; }
         public bool HasSAO { get; set; }
+        public List<string> MediaTitles { get; set; }
     }
 }

--- a/Annie/Modules/HelpModule.cs
+++ b/Annie/Modules/HelpModule.cs
@@ -27,6 +27,7 @@ namespace AnnieMayDiscordBot.Modules
                 .AddField($"{Resources.PREFIX}staff `CRITERIA`", "Finds one staff from AniList's database.")
                 .AddField($"{Resources.PREFIX}studio `CRITERIA`", "Finds one studio from AniList's database.")
                 .AddField($"{Resources.PREFIX}user `ANILIST_USERNAME`", "Shows a User's Anilist statistics.")
+                .AddField($"{Resources.PREFIX}scores `ANILIST_USERNAME`", "Shows a User's Anilist scores.")
                 .AddField($"{Resources.PREFIX}setup anilist `ANILIST_USERNAME`", "Adds a User's Anilist to the database for future usage.")
                 .WithDescription($"For more descriptive help, type {Resources.PREFIX}help `COMMAND`")
                 .WithColor(Color.DarkRed);
@@ -183,6 +184,24 @@ namespace AnnieMayDiscordBot.Modules
                 .AddField($"{Resources.PREFIX}user `USERNAME`", "Specify the username of the user.")
                 .AddField($"{Resources.PREFIX}user `ID`", "Specify the id of the user.")
                 .WithDescription($"Finds the user with the given username or ID and displays their anime & manga list statistics.\n\nExample usage: `{Resources.PREFIX}user SmellyAlex`\n\n_{builder.Fields.Count} overloads exist for this command._")
+                .WithColor(Color.DarkRed);
+
+            return ReplyAsync("", false, builder.Build());
+        }
+
+        /// <summary>
+        /// Shows help for the scores command.
+        /// </summary>
+        /// <returns>An Embed reply regarding the Scores command.</returns>
+        [Command("scores")]
+        [Alias("scoredistribution", "userscores")]
+        public Task HelpScoresAsync()
+        {
+            EmbedBuilder builder = new EmbedBuilder();
+            builder.WithTitle($"{Resources.PREFIX}scores")
+                .AddField($"{Resources.PREFIX}scores `USERNAME`", "Specify the Anilist username of the user.")
+                .AddField($"{Resources.PREFIX}scores `ID`", "Specify the Discord or Anilist id of the user.")
+                .WithDescription($"Finds the user with the given username or ID and displays their Anilist scores breakdown.\n\nExample usage: `{Resources.PREFIX}scores SmellyAlex`\n\n_{builder.Fields.Count} overloads exist for this command._")
                 .WithColor(Color.DarkRed);
 
             return ReplyAsync("", false, builder.Build());

--- a/Annie/Modules/ScoreModule.cs
+++ b/Annie/Modules/ScoreModule.cs
@@ -6,12 +6,14 @@ using System.Threading.Tasks;
 
 namespace AnnieMayDiscordBot.Modules
 {
+    [Group("scores")]
+    [Alias("scoredistribution", "userscores")]
     public class ScoreModule : AbstractModule
     {
         /// <summary>
         /// Get a compiled list of the scored Media for the User. No arguments defaults to Anime.
         /// </summary>
-        [Command("scores")]
+        [Command]
         [Summary("Get a compiled list of the scored Media for the User.")]
         public async Task GetUserScoresAsync()
         {
@@ -29,7 +31,7 @@ namespace AnnieMayDiscordBot.Modules
         /// Get a compiled list of the scored Media for the specified Anilist username without parameters.
         /// </summary>
         /// <param name="username">An Anilist username.</param>s
-        [Command("scores")]
+        [Command]
         [Summary("Get a compiled list of the scored Media for the specified Anilist username without parameters.")]
         public async Task GetUserScoresAsync(string username)
         {
@@ -41,7 +43,7 @@ namespace AnnieMayDiscordBot.Modules
         /// Get a compiled list of the scored Media for the specified Anilist userId without parameters.
         /// </summary>
         /// <param name="userId">An Anilist User ID.</param>s
-        [Command("scores")]
+        [Command]
         [Summary("Get a compiled list of the scored Media for the User without parameters.")]
         public async Task GetUserScoresAsync(long userId)
         {
@@ -65,7 +67,7 @@ namespace AnnieMayDiscordBot.Modules
         /// Get a compiled list of the scored Media for the Discord User without parameters.
         /// </summary>
         /// <param name="user">The tagged Discord User.</param>
-        [Command("scores")]
+        [Command]
         [Summary("Get a compiled list of the scored Media for the Discord User without parameters.")]
         public async Task GetUserScoresAsync(IUser user)
         {

--- a/Annie/Modules/ScoreModule.cs
+++ b/Annie/Modules/ScoreModule.cs
@@ -2,6 +2,8 @@
 using AnnieMayDiscordBot.ResponseModels.Anilist;
 using Discord;
 using Discord.Commands;
+using System;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace AnnieMayDiscordBot.Modules
@@ -30,7 +32,7 @@ namespace AnnieMayDiscordBot.Modules
         /// <summary>
         /// Get a compiled list of the scored Media for the specified Anilist username without parameters.
         /// </summary>
-        /// <param name="username">An Anilist username.</param>s
+        /// <param name="username">An Anilist username.</param>
         [Command]
         [Summary("Get a compiled list of the scored Media for the specified Anilist username without parameters.")]
         public async Task GetUserScoresAsync(string username)
@@ -40,9 +42,9 @@ namespace AnnieMayDiscordBot.Modules
         }
 
         /// <summary>
-        /// Get a compiled list of the scored Media for the specified Anilist userId without parameters.
+        /// Get a compiled list of the scored Media for the specified Discord or Anilist userId without parameters.
         /// </summary>
-        /// <param name="userId">An Anilist User ID.</param>s
+        /// <param name="userId">An Anilist User ID.</param>
         [Command]
         [Summary("Get a compiled list of the scored Media for the User without parameters.")]
         public async Task GetUserScoresAsync(long userId)
@@ -77,8 +79,232 @@ namespace AnnieMayDiscordBot.Modules
                 await ReplyAsync($"Wait who dat? Please have them register their Anilist using `{Properties.Resources.PREFIX}setup anilist <USERNAME/ID>`");
                 return;
             }
+
             MediaListCollectionResponse response = await _aniListFetcher.FindUserListScoresAsync(discordUser.anilistId, MediaType.Anime.ToString());
             await ReplyAsync(null, false, _embedUtility.BuildScoresEmbed(response.MediaListCollection, MediaType.Anime));
+        }
+
+        /// <summary>
+        /// Get a compiled list of the scored Media for the specified Anilist username with parameters.
+        /// </summary>
+        /// <param name="username">An Anilist username.</param>
+        /// <param name="parameters">The parameters attached to the request.</param>
+        [Command]
+        [Summary("Get a compiled list of the scored Media for the specified Anilist username with parameters.")]
+        public async Task GetUserScoresAsync(string username, [Remainder] string parameters)
+        {
+            var tuple = ParseParameters(parameters);
+            // No bounds specified.
+            if (tuple.Item2 == 0 && tuple.Item3 == 100)
+            {
+                MediaListCollectionResponse response = await _aniListFetcher.FindUserListScoresAsync(username, tuple.Item1.ToString());
+                await ReplyAsync(null, false, _embedUtility.BuildScoresEmbed(response.MediaListCollection, tuple.Item1));
+            }
+            // Bounds specified.
+            else
+            {
+                MediaListCollectionResponse response = await _aniListFetcher.FindUserListScoresAsync(username, tuple.Item1.ToString());
+                await ReplyAsync(null, false, _embedUtility.BuildCustomScoresEmbed(response.MediaListCollection, tuple.Item1, tuple.Item2, tuple.Item3));
+            }
+        }
+
+        /// <summary>
+        /// Get a compiled list of the scored Media for the specified Discord or Anilist userId with parameters.
+        /// </summary>
+        /// <param name="userId">An Anilist User ID.</param>
+        /// <param name="parameters">The parameters attached to the request.</param>
+        [Command]
+        [Summary("Get a compiled list of the scored Media for the specified Discord or Anilist userId with parameters.")]
+        public async Task GetUserScoresAsync(long userId, [Remainder] string parameters)
+        {
+            // Check if the given long parameter is a Discord User ID (17-18 characters long).
+            if (userId.ToString().Length >= 17)
+            {
+                var user = await _databaseUtility.GetSpecificUserAsync((ulong)userId);
+                if (user == null)
+                {
+                    await ReplyAsync("This filthy weeb isn't in the database.");
+                    return;
+                }
+                // Overwrite the userId with the found Anilist ID.
+                userId = user.anilistId;
+            }
+
+            var tuple = ParseParameters(parameters);
+            // No bounds specified.
+            if (tuple.Item2 == 0 && tuple.Item3 == 100)
+            {
+                MediaListCollectionResponse response = await _aniListFetcher.FindUserListScoresAsync(userId, tuple.Item1.ToString());
+                await ReplyAsync(null, false, _embedUtility.BuildScoresEmbed(response.MediaListCollection, tuple.Item1));
+            }
+            // Bounds specified.
+            else
+            {
+                MediaListCollectionResponse response = await _aniListFetcher.FindUserListScoresAsync(userId, tuple.Item1.ToString());
+                await ReplyAsync(null, false, _embedUtility.BuildCustomScoresEmbed(response.MediaListCollection, tuple.Item1, tuple.Item2, tuple.Item3));
+            }
+        }
+
+        /// <summary>
+        /// Get a compiled list of the scored Media for the Discord User with parameters.
+        /// </summary>
+        /// <param name="user">The tagged Discord User.</param>
+        /// <param name="parameters">The parameters attached to the request.</param>
+        [Command]
+        [Summary("Get a compiled list of the scored Media for the Discord User with parameters.")]
+        public async Task GetUserScoresAsync(IUser user, [Remainder] string parameters)
+        {
+            var discordUser = await _databaseUtility.GetSpecificUserAsync(user.Id);
+            if (discordUser == null)
+            {
+                await ReplyAsync($"Wait who dat? Please have them register their Anilist using `{Properties.Resources.PREFIX}setup anilist <USERNAME/ID>`");
+                return;
+            }
+
+            var tuple = ParseParameters(parameters);
+            // No bounds specified.
+            if (tuple.Item2 == 0 && tuple.Item3 == 100)
+            {
+                MediaListCollectionResponse response = await _aniListFetcher.FindUserListScoresAsync(discordUser.anilistId, tuple.Item1.ToString());
+                await ReplyAsync(null, false, _embedUtility.BuildScoresEmbed(response.MediaListCollection, tuple.Item1));
+            }
+            // Bounds specified.
+            else
+            {
+                MediaListCollectionResponse response = await _aniListFetcher.FindUserListScoresAsync(discordUser.anilistId, tuple.Item1.ToString());
+                await ReplyAsync(null, false, _embedUtility.BuildCustomScoresEmbed(response.MediaListCollection, tuple.Item1, tuple.Item2, tuple.Item3));
+            }
+        }
+
+        /// <summary>
+        /// Parse parameters that are added to the command.
+        /// </summary>
+        /// <param name="parameters">The parameters attached to the request.</param>
+        /// <returns>A Tuple containing a MediaType string and lower and upper bounds ints.</returns>
+        private Tuple<MediaType, int, int> ParseParameters(string parameters)
+        {
+            // Lower parameters.
+            parameters = parameters.ToLower();
+            // Check for anime/manga parameters.
+            bool hasAnime = parameters.Contains("anime");
+            bool hasManga = parameters.Contains("manga");
+
+            // Both anime and manga in the parameters is not allowed.
+            if (hasAnime && hasManga)
+            {
+                ReplyAsync("Failed to parse parameters. There can only be zero or one anime or manga parameter.");
+                return null;
+            }
+
+            // Remove anime and manga parameters.
+            parameters = parameters.Replace("anime", "").Replace("manga", "").Trim();
+
+            // Check for <, >, =, >= or <= followed by a number.
+            var matches = Regex.Matches(parameters, "((>=|<=|>|<|=){1}\\d+)");
+
+            // Set bounds based on appropriate parameters.
+            var bounds = Tuple.Create(0, 100);
+            if (matches.Count > 0)
+            {
+                var minMaxTuple = CalculateBounds(matches);
+                if (minMaxTuple != null)
+                {
+                    bounds = minMaxTuple;
+                }
+            }
+
+            // If no manga was specified, it means either nothing or anime was given, defaulting to anime.
+            if (!hasManga)
+            {
+                return Tuple.Create(MediaType.Anime, bounds.Item1, bounds.Item2);
+            }
+            // Else manga was the choise.
+            return Tuple.Create(MediaType.Manga, bounds.Item1, bounds.Item2);
+        }
+
+        /// <summary>
+        /// Handle the matches to determine the scoring bounds.
+        /// </summary>
+        /// <param name="matches">The Regex matches fo</param>
+        /// <returns>A Tuple containing the lower and upper bounds ints from the matches.</returns>
+        private Tuple<int, int> CalculateBounds(MatchCollection matches)
+        {
+            int lowerBounds = 0;
+            int upperBounds = 100;
+            foreach (var match in matches)
+            {
+                Regex re = new Regex("([><=]+)(\\d+)");
+                Match result = re.Match(match.ToString());
+
+                string alphaPart = result.Groups[1].Value;
+                int numberPart = int.Parse(result.Groups[2].Value);
+                // More than.
+                if (alphaPart.Equals(">"))
+                {
+                    // Check if possible with current bounds.
+                    if (numberPart >= lowerBounds && numberPart <= upperBounds)
+                    {
+                        // More than means it cannot be the number itself, but can be 1 more.
+                        lowerBounds = numberPart + 1;
+                    }
+                }
+                // Less than.
+                else if (alphaPart.Equals("<"))
+                {
+                    // Check if possible with current bounds.
+                    if (numberPart >= lowerBounds && numberPart <= upperBounds)
+                    {
+                        // Less than means it cannot be the number itself, but can be 1 less.
+                        upperBounds = numberPart - 1;
+                    }
+                }
+                // Equals.
+                else if (alphaPart.Equals("="))
+                {
+                    // Check if possible with current bounds.
+                    if (numberPart >= lowerBounds && numberPart <= upperBounds)
+                    {
+                        // Equals is self-explanatory.
+                        upperBounds = numberPart;
+                        lowerBounds = numberPart;
+                    }
+                }
+                // More than or equals.
+                else if (alphaPart.Equals(">="))
+                {
+                    // Check if possible with current bounds.
+                    if (numberPart >= lowerBounds && numberPart <= upperBounds)
+                    {
+                        // Less than means lower bounds needs to be adjusted.
+                        lowerBounds = numberPart;
+                    }
+                }
+                // Less than or equals.
+                else if (alphaPart.Equals("<="))
+                {
+                    // Check if possible with current bounds.
+                    if (numberPart >= lowerBounds && numberPart <= upperBounds)
+                    {
+                        // Less than means upper bounds needs to be adjusted.
+                        upperBounds = numberPart;
+                    }
+                }
+                // Anything else is not allowed so reply with an error.
+                else
+                {
+                    ReplyAsync("Failed to parse parameters. There can only be `>`, `<`, `=`, `>=`, `<=` comparator parameters.");
+                    return null;
+                }
+            }
+
+            // Check if lower and upper bounds are possible together.
+            if (lowerBounds > upperBounds)
+            {
+                ReplyAsync("Failed to parse parameters. Your lower bounds cannot be higher than your upper bounds.");
+                return null;
+            }
+
+            return Tuple.Create(lowerBounds, upperBounds);
         }
     }
 }

--- a/Annie/Modules/ScoreModule.cs
+++ b/Annie/Modules/ScoreModule.cs
@@ -1,0 +1,82 @@
+﻿using AnnieMayDiscordBot.Enums.Anilist;
+using AnnieMayDiscordBot.ResponseModels.Anilist;
+using Discord;
+using Discord.Commands;
+using System.Threading.Tasks;
+
+namespace AnnieMayDiscordBot.Modules
+{
+    public class ScoreModule : AbstractModule
+    {
+        /// <summary>
+        /// Get a compiled list of the scored Media for the User. No arguments defaults to Anime.
+        /// </summary>
+        [Command("scores")]
+        [Summary("Get a compiled list of the scored Media for the User.")]
+        public async Task GetUserScoresAsync()
+        {
+            var user = await _databaseUtility.GetSpecificUserAsync(Context.User.Id);
+            if (user == null)
+            {
+                await ReplyAsync($"Wait who dis? Please register your Anilist using `{Properties.Resources.PREFIX}setup anilist <USERNAME/ID>`");
+                return;
+            }
+            MediaListCollectionResponse response = await _aniListFetcher.FindUserListScoresAsync(user.anilistId, MediaType.Anime.ToString());
+            await ReplyAsync(null, false, _embedUtility.BuildScoresEmbed(response.MediaListCollection, MediaType.Anime));
+        }
+
+        /// <summary>
+        /// Get a compiled list of the scored Media for the specified Anilist username without parameters.
+        /// </summary>
+        /// <param name="username">An Anilist username.</param>s
+        [Command("scores")]
+        [Summary("Get a compiled list of the scored Media for the specified Anilist username without parameters.")]
+        public async Task GetUserScoresAsync(string username)
+        {
+            MediaListCollectionResponse response = await _aniListFetcher.FindUserListScoresAsync(username, MediaType.Anime.ToString());
+            await ReplyAsync(null, false, _embedUtility.BuildScoresEmbed(response.MediaListCollection, MediaType.Anime));
+        }
+
+        /// <summary>
+        /// Get a compiled list of the scored Media for the specified Anilist userId without parameters.
+        /// </summary>
+        /// <param name="userId">An Anilist User ID.</param>s
+        [Command("scores")]
+        [Summary("Get a compiled list of the scored Media for the User without parameters.")]
+        public async Task GetUserScoresAsync(long userId)
+        {
+            // Check if the given long parameter is a Discord User ID (17-18 characters long).
+            if (userId.ToString().Length >= 17)
+            {
+                var user = await _databaseUtility.GetSpecificUserAsync((ulong)userId);
+                if (user == null)
+                {
+                    await ReplyAsync("This filthy weeb isn't in the database.");
+                    return;
+                }
+                // Overwrite the userId with the found Anilist ID.
+                userId = user.anilistId;
+            }
+            MediaListCollectionResponse response = await _aniListFetcher.FindUserListScoresAsync(userId, MediaType.Anime.ToString());
+            await ReplyAsync(null, false, _embedUtility.BuildScoresEmbed(response.MediaListCollection, MediaType.Anime));
+        }
+
+        /// <summary>
+        /// Get a compiled list of the scored Media for the Discord User without parameters.
+        /// </summary>
+        /// <param name="user">The tagged Discord User.</param>
+        [Command("scores")]
+        [Summary("Get a compiled list of the scored Media for the Discord User without parameters.")]
+        public async Task GetUserScoresAsync(IUser user)
+        {
+            var discordUser = await _databaseUtility.GetSpecificUserAsync(user.Id);
+            if (discordUser == null)
+            {
+                await ReplyAsync($"Wait who dat? Please have them register their Anilist using `{Properties.Resources.PREFIX}setup anilist <USERNAME/ID>`");
+                return;
+            }
+            MediaListCollectionResponse response = await _aniListFetcher.FindUserListScoresAsync(discordUser.anilistId, MediaType.Anime.ToString());
+            await ReplyAsync(null, false, _embedUtility.BuildScoresEmbed(response.MediaListCollection, MediaType.Anime));
+        }
+    }
+}

--- a/Annie/Services/AniListFetcher.cs
+++ b/Annie/Services/AniListFetcher.cs
@@ -655,17 +655,18 @@ namespace AnnieMayDiscordBot.Services
         }
 
         /// <summary>
-        ///
+        /// Find a specific Anilist User's Media list data from the Anilist GraphQL API using their username.
         /// </summary>
-        /// <param name="anilistId"></param>
-        /// <param name="mediaType"></param>
-        /// <returns>The User response from Anilist GraphQL API with all their list data.</returns>
+        /// <param name="anilistName">The username of the Anilist user.</param>
+        /// <param name="mediaType">The MediaType of the Media entry. Either ANIME or MANGA.</param>
+        /// <returns>The MediaListCollection response from Anilist GraphQL API with all their list data.</returns>
         public async Task<MediaListCollectionResponse> FindUserListScoresAsync(string anilistName, string mediaType)
         {
             string query = @"
                 query ($username: String, $type: MediaType) {
                     MediaListCollection(userName: $username, type: $type, status: COMPLETED) {
                         user {
+                            id
                             name
                             avatar {
                                 large
@@ -677,6 +678,7 @@ namespace AnnieMayDiscordBot.Services
                                 media {
                                   title {
                                     english
+                                    romaji
                                   }
                                 }
                                 score(format: POINT_100)
@@ -695,17 +697,18 @@ namespace AnnieMayDiscordBot.Services
         }
 
         /// <summary>
-        ///
+        /// Find a specific Anilist User's Media list data from the Anilist GraphQL API using their ID.
         /// </summary>
-        /// <param name="anilistId"></param>
-        /// <param name="mediaType"></param>
-        /// <returns>The User response from Anilist GraphQL API with all their list data.</returns>
+        /// <param name="anilistId">The ID of the Anilist user.</param>
+        /// <param name="mediaType">The MediaType of the Media entry. Either ANIME or MANGA.</param>
+        /// <returns>The MediaListCollection response from Anilist GraphQL API with all their list data.</returns>
         public async Task<MediaListCollectionResponse> FindUserListScoresAsync(long anilistId, string mediaType)
         {
             string query = @"
                 query ($user_id: Int, $type: MediaType) {
                     MediaListCollection(userId: $user_id, type: $type, status: COMPLETED) {
                         user {
+                            id
                             name
                             avatar {
                                 large
@@ -717,6 +720,7 @@ namespace AnnieMayDiscordBot.Services
                                 media {
                                   title {
                                     english
+                                    romaji
                                   }
                                 }
                                 score(format: POINT_100)

--- a/Annie/Services/AniListFetcher.cs
+++ b/Annie/Services/AniListFetcher.cs
@@ -655,6 +655,86 @@ namespace AnnieMayDiscordBot.Services
         }
 
         /// <summary>
+        ///
+        /// </summary>
+        /// <param name="anilistId"></param>
+        /// <param name="mediaType"></param>
+        /// <returns>The User response from Anilist GraphQL API with all their list data.</returns>
+        public async Task<MediaListCollectionResponse> FindUserListScoresAsync(string anilistName, string mediaType)
+        {
+            string query = @"
+                query ($username: String, $type: MediaType) {
+                    MediaListCollection(userName: $username, type: $type, status: COMPLETED) {
+                        user {
+                            name
+                            avatar {
+                                large
+                            }
+                            siteUrl
+                        }
+                        lists {
+                            entries {
+                                media {
+                                  title {
+                                    english
+                                  }
+                                }
+                                score(format: POINT_100)
+                            }
+                        }
+                    }
+                }";
+
+            object variables = new
+            {
+                username = anilistName,
+                type = mediaType.ToUpper()
+            };
+
+            return await _graphQLUtility.ExecuteGraphQLRequest<MediaListCollectionResponse>(query, variables);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="anilistId"></param>
+        /// <param name="mediaType"></param>
+        /// <returns>The User response from Anilist GraphQL API with all their list data.</returns>
+        public async Task<MediaListCollectionResponse> FindUserListScoresAsync(long anilistId, string mediaType)
+        {
+            string query = @"
+                query ($user_id: Int, $type: MediaType) {
+                    MediaListCollection(userId: $user_id, type: $type, status: COMPLETED) {
+                        user {
+                            name
+                            avatar {
+                                large
+                            }
+                            siteUrl
+                        }
+                        lists {
+                            entries {
+                                media {
+                                  title {
+                                    english
+                                  }
+                                }
+                                score(format: POINT_100)
+                            }
+                        }
+                    }
+                }";
+
+            object variables = new
+            {
+                user_id = anilistId,
+                type = mediaType.ToUpper()
+            };
+
+            return await _graphQLUtility.ExecuteGraphQLRequest<MediaListCollectionResponse>(query, variables);
+        }
+
+        /// <summary>
         /// Find the score for a User that they gave to a specific Media entry using their Anilist User ID.
         /// </summary>
         /// <param name="anilistId">The ID of the Anilist user.</param>

--- a/Annie/Utility/EmbedUtility.cs
+++ b/Annie/Utility/EmbedUtility.cs
@@ -675,44 +675,59 @@ namespace AnnieMayDiscordBot.Utility
                 };
                 userScoresList.Add(userScores);
             }
-            int unscored = 0;
-            // Read all the list values.
-            foreach (var entry in mediaListCollection.Lists[0].Entries)
-            {
-                // Track unscores entries.
-                if (entry.Score == 0)
-                {
-                    unscored++;
-                }
-                // Otherwise go look for the current UserScores in the list.
-                else
-                {
-                    // Check for SAO
-                    bool isSao = entry.Media.Title.English != null && entry.Media.Title.English.ToLower().Contains("sword art online");
 
-                    foreach (var userScores in userScoresList)
+            int unscored = 0;
+            if (mediaListCollection.Lists.Count > 0)
+            {
+                // Read all the list values.
+                foreach (var entry in mediaListCollection.Lists[0].Entries)
+                {
+                    // Track unscores entries.
+                    if (entry.Score == 0)
                     {
-                        // Check if the score falls within the two score bounds.
-                        if (userScores.UpperBound >= entry.Score && entry.Score >= userScores.LowerBound)
+                        unscored++;
+                    }
+                    // Otherwise go look for the current UserScores in the list.
+                    else
+                    {
+                        // Check for SAO
+                        bool isSao = entry.Media.Title.English != null && entry.Media.Title.English.ToLower().Contains("sword art online");
+
+                        foreach (var userScores in userScoresList)
                         {
-                            // Increment count.
-                            userScores.Count++;
-                            // Check for SAO.
-                            if (isSao)
+                            // Check if the score falls within the two score bounds.
+                            if (userScores.UpperBound >= entry.Score && entry.Score >= userScores.LowerBound)
                             {
-                                userScores.HasSAO = true;
+                                // Increment count.
+                                userScores.Count++;
+                                // Check for SAO.
+                                if (isSao)
+                                {
+                                    userScores.HasSAO = true;
+                                }
+                                break;
                             }
-                            break;
                         }
                     }
                 }
             }
+
             // Format the scores.
             foreach (var userScores in userScoresList)
             {
-                float percentage = userScores.Count / mediaListCollection.Lists[0].Entries.Count * 100;
+                var items = 0;
+                if (mediaListCollection.Lists.Count > 0)
+                {
+                    items = mediaListCollection.Lists[0].Entries.Count;
+                }
+                float percentage = 0;
+                if (items != 0)
+                {
+                    percentage = userScores.Count / items * 100;
+                }
                 string formatted = $"_{userScores.LowerBound}-{userScores.UpperBound}_: **{userScores.Count}x**" +
                     $" ~ _{percentage.ToString("N2", CultureInfo.InvariantCulture)}%_";
+                
                 // Check for and add sao score.
                 if (userScores.HasSAO)
                 {
@@ -721,10 +736,109 @@ namespace AnnieMayDiscordBot.Utility
                 formattedScores.Add(formatted);
             }
 
+            // Custom fun override for specific user.
+            if (mediaListCollection.User.Id == 210768 && mediaType.Equals(MediaType.Manga))
+            {
+                formattedScores.Add($"_-100_: **{int.MaxValue}x** ~ _100%_");
+            }
+
             // Add unscored.
             formattedScores.Add($"_No Score: {unscored}_");
+            
+            embedBuilder.WithDescription($"**{mediaType} Scores**\n\n{string.Join("\n", formattedScores)}");
 
-            embedBuilder.WithDescription($"**{mediaType} Scores**\n\n{string.Join("\n", formattedScores)}")
+            // Add all extra properties.
+            embedBuilder.WithThumbnailUrl(mediaListCollection.User.Avatar.Large)
+                .WithTitle(mediaListCollection.User.Name)
+                .WithUrl(mediaListCollection.User.SiteUrl);
+
+            return embedBuilder.Build();
+        }
+
+        /// <summary>
+        /// Build the Discord embed for media entries within bounds from an Anilist MediaListCollection entry.
+        /// </summary>
+        /// <param name="mediaListCollection">The Anilist MediaListCollection.</param>
+        /// <param name="mediaType">The MediaType the scores are for.</param>
+        /// <param name="min">The lowest score allowed.</param>
+        /// <param name="max">The highest score allowed.</param>
+        /// <returns>The Discord.NET Embed object.</returns>
+        public Embed BuildCustomScoresEmbed(MediaListCollection mediaListCollection, MediaType mediaType, int min, int max)
+        {
+            EmbedBuilder embedBuilder = new EmbedBuilder();
+
+            // Populate list of UserScores.
+            var userScoresList = new List<UserScores>();
+            for (int i = 10; i > 0; i--)
+            {
+                var userScores = new UserScores
+                {
+                    UpperBound = 10 * i,
+                    LowerBound = 10 * (i - 1) + 1,
+                    MediaTitles = new List<string>()
+                };
+                userScoresList.Add(userScores);
+            }
+
+            if (mediaListCollection.Lists.Count > 0)
+            {
+                // Loop over the media entries to find within bounds.
+                foreach (var entry in mediaListCollection.Lists[0].Entries)
+                {
+                    // Only handle entry if it falls within bounds.
+                    if (entry.Score >= min && entry.Score <= max)
+                    {
+                        // Find the corresponding UserScores to add it to the list.
+                        foreach (var userScores in userScoresList)
+                        {
+                            // Check if the score falls within the two score bounds.
+                            if (userScores.UpperBound >= entry.Score && entry.Score >= userScores.LowerBound)
+                            {
+                                userScores.MediaTitles.Add(entry.Media.Title.English ?? entry.Media.Title.Romaji);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            
+            // Start formatting the description.
+            string description = $"**{mediaType} scored between {min} and {max}**\n\n";
+            int totalMedia = 0;
+            foreach (var userScores in userScoresList)
+            {
+                // Skip to the next list item if it doesn't fall within the bounds.
+                if (userScores.LowerBound < min && userScores.UpperBound > max)
+                {
+                    continue;
+                }
+                
+                // Make sure to skip empty lists.
+                if (userScores.MediaTitles.Count > 0)
+                {
+                    totalMedia += userScores.MediaTitles.Count;
+                    description += $"**{userScores.LowerBound}-{userScores.UpperBound}**\n";
+                    description += $"{string.Join("\n", userScores.MediaTitles)}\n\n";
+                }
+
+                // If limit has been reached on description, cut it off with an ellipsis and break out of the loop.
+                if (description.Length > DESCRIPTION_LIMIT)
+                {
+                    description = CutStringWithEllipsis(description);
+                    break;
+                }
+            }
+
+            embedBuilder.WithDescription(description);
+
+            // Override description if no media was added.
+            if (totalMedia == 0)
+            {
+                embedBuilder.WithDescription(description + "No entries found for these bounds.");
+            }
+
+            // Add all extra properties.
+            embedBuilder.WithFooter("Some entries may be hidden because of the Anilist and/or Discord limit...")
                 .WithThumbnailUrl(mediaListCollection.User.Avatar.Large)
                 .WithTitle(mediaListCollection.User.Name)
                 .WithUrl(mediaListCollection.User.SiteUrl);


### PR DESCRIPTION
Multiple implementations:
* Regular breakdown of a User's Anilist scores with amount and percentage.
* Specify a range to fetch, such as `>50 <80`, to display the anime within those bounds.